### PR TITLE
Add performance benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 os: 'linux'
 script:
   - pnpm run build && pnpm run test:ci
+  - pnpm run benchmark
 after_script:
   - bash <(curl -s https://codecov.io/bash)
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-sudo: false
 language: node_js
 node_js:
   - '10.16.0'
+os: 'linux'
 script:
   - pnpm run build && pnpm run test:ci
 after_script:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+codecov:
+  ci:
+    - "travis.org"
+comment: false

--- a/package.json
+++ b/package.json
@@ -17,15 +17,21 @@
   "license": "MIT",
   "devDependencies": {
     "@types/assert": "^1.4.4",
+    "@types/benchmark": "^1.0.31",
     "@types/mocha": "^5.2.7",
     "assert": "^2.0.0",
+    "benchmark": "github:bestiejs/benchmark.js#42f3b732bac3640eddb3ae5f50e445f3141016fd",
+    "callbag-basics": "^3.2.0",
     "fast-check": "^1.21.0",
     "mocha": "^7.0.1",
+    "most": "^1.8.0",
     "nyc": "^15.0.0",
     "prettier": "^1.19.1",
     "rollup": "^1.29.1",
+    "rxjs": "^6.5.4",
     "ts-node": "^8.6.2",
-    "typescript": "^3.7.5"
+    "typescript": "^3.7.5",
+    "xstream": "^11.11.0"
   },
   "prettier": {
     "singleQuote": true

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "nyc --reporter text --reporter html pnpm run test:no_cover",
     "test:ci": "nyc --reporter text --reporter json pnpm run test:no_cover",
     "test:no_cover": "mocha --require ts-node/register 'test/*.ts'",
+    "benchmark": "ts-node perf/index.ts",
     "prepublishOnly": "pnpm test && pnpm run build"
   },
   "author": "Jan van Brügge",

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,16 @@
+# Performance results
+
+Run on a Lenovo Yoga X1 2nd Gen, 2.7 GHz Intel Core i7, ts-node `v8.6.2`
+
+## fold
+
+```
+scan -> scan 1000000 integers
+-----------------------------------------------------
+@cycle/callbags    25.69 op/s ±  0.59%   (63 samples)
+callbag-basics     26.60 op/s ±  0.71%   (65 samples)
+xstream            14.49 op/s ±  1.29%   (69 samples)
+rxjs               15.10 op/s ±  1.75%   (72 samples)
+most               27.80 op/s ±  1.97%   (67 samples)
+-----------------------------------------------------
+```

--- a/perf/README.md
+++ b/perf/README.md
@@ -7,10 +7,21 @@ Run on a Lenovo Yoga X1 2nd Gen, 2.7 GHz Intel Core i7, ts-node `v8.6.2`
 ```
 scan -> scan 1000000 integers
 -----------------------------------------------------
-@cycle/callbags    25.17 op/s ±  0.87%   (62 samples)
-callbag-basics     24.98 op/s ±  1.05%   (62 samples)
-xstream            14.03 op/s ±  1.67%   (68 samples)
-rxjs               14.29 op/s ±  3.08%   (70 samples)
-most               28.32 op/s ±  1.86%   (67 samples)
+@cycle/callbags    24.98 op/s ±  1.02%   (61 samples)
+xstream            14.11 op/s ±  1.35%   (67 samples)
+rxjs               14.06 op/s ±  2.24%   (67 samples)
+most               28.22 op/s ±  2.05%   (67 samples)
+-----------------------------------------------------
+```
+
+## dataflow
+
+```
+dataflow for 1000000 source events
+-----------------------------------------------------
+@cycle/callbags     8.53 op/s ±  2.37%   (45 samples)
+xstream             4.67 op/s ±  0.79%   (27 samples)
+rxjs                5.79 op/s ±  1.83%   (32 samples)
+most               13.89 op/s ±  1.77%   (68 samples)
 -----------------------------------------------------
 ```

--- a/perf/README.md
+++ b/perf/README.md
@@ -7,10 +7,10 @@ Run on a Lenovo Yoga X1 2nd Gen, 2.7 GHz Intel Core i7, ts-node `v8.6.2`
 ```
 scan -> scan 1000000 integers
 -----------------------------------------------------
-@cycle/callbags    25.69 op/s ±  0.59%   (63 samples)
-callbag-basics     26.60 op/s ±  0.71%   (65 samples)
-xstream            14.49 op/s ±  1.29%   (69 samples)
-rxjs               15.10 op/s ±  1.75%   (72 samples)
-most               27.80 op/s ±  1.97%   (67 samples)
+@cycle/callbags    25.17 op/s ±  0.87%   (62 samples)
+callbag-basics     24.98 op/s ±  1.05%   (62 samples)
+xstream            14.03 op/s ±  1.67%   (68 samples)
+rxjs               14.29 op/s ±  3.08%   (70 samples)
+most               28.32 op/s ±  1.86%   (67 samples)
 -----------------------------------------------------
 ```

--- a/perf/dataflow.ts
+++ b/perf/dataflow.ts
@@ -1,0 +1,88 @@
+import { Suite } from 'benchmark';
+import { options, runCallbags, runXStream, runRxJs, runMost } from './helpers';
+
+import {
+  fromArray,
+  map,
+  scan,
+  filter,
+  combineWith,
+  pipe,
+  merge
+} from '../src/index';
+import xs from 'xstream';
+import { from as rxjsFrom, merge as rxjsMerge, combineLatest } from 'rxjs';
+import * as rxjs from 'rxjs/operators';
+import * as most from 'most';
+
+const arr = Array(options.size)
+  .fill(0)
+  .map(() => Math.sin(Math.random() * 100000));
+
+const isPositive = (x: number) => x > 0;
+const isNegative = (x: number) => x < 0;
+const add = (x: number, y: number) => x + y;
+const renderArray = (arr: any[]) => ({ label: arr[0], count: [1] });
+const renderArgs = (x: any, y: any) => ({ label: x, count: y });
+
+export const dataflow = new Suite(`dataflow for ${options.size} source events`)
+  .add(
+    '@cycle/callbags',
+    runCallbags(() => {
+      const source = fromArray(arr);
+      const inc = pipe(
+        source,
+        filter(isPositive),
+        map(() => +1)
+      );
+      const dec = pipe(
+        source,
+        filter(isNegative),
+        map(() => -1)
+      );
+      const count = pipe(merge(inc, dec), scan(add, 0));
+      const label = fromArray(['initial', 'Count is ']);
+
+      return combineWith(renderArgs, label, count);
+    }),
+    options
+  )
+  .add(
+    'xstream',
+    runXStream(() => {
+      const source = xs.fromArray(arr);
+      const inc = source.filter(isPositive).mapTo(+1);
+      const dec = source.filter(isNegative).mapTo(-1);
+      const count = xs.merge(inc, dec).fold(add, 0);
+      const label = xs.of('initial', 'Count is ');
+
+      return xs.combine(label, count).map(renderArray);
+    }),
+    options
+  )
+  .add(
+    'rxjs',
+    runRxJs(() => {
+      const source = rxjsFrom(arr);
+      const inc = source.pipe(rxjs.filter(isPositive), rxjs.mapTo(+1));
+      const dec = source.pipe(rxjs.filter(isNegative), rxjs.mapTo(-1));
+      const count = rxjsMerge(inc, dec).pipe(rxjs.scan(add, 0));
+      const label = rxjsFrom(['initial', 'Count is ']);
+
+      return combineLatest(label, count, renderArgs);
+    }),
+    options
+  )
+  .add(
+    'most',
+    runMost(() => {
+      const source = most.from(arr);
+      const inc = source.filter(isPositive).map(() => +1);
+      const dec = source.filter(isNegative).map(() => -1);
+      const count = most.merge(inc, dec).scan(add, 0);
+      const label = most.from(['initial', 'Count is ']);
+
+      return most.combine(renderArgs, label, count);
+    }),
+    options
+  );

--- a/perf/fold.ts
+++ b/perf/fold.ts
@@ -1,19 +1,11 @@
 import { Suite } from 'benchmark';
-import {
-  options,
-  runXStream,
-  runCallbags,
-  runCallbagBasics,
-  runRxJs,
-  runMost
-} from './helpers';
+import { options, runXStream, runCallbags, runRxJs, runMost } from './helpers';
 
 import { pipe, fromArray, scan } from '../src/index';
 import xs from 'xstream';
 import { from as rxjsFrom } from 'rxjs';
 import * as rxjs from 'rxjs/operators';
 import * as most from 'most';
-import * as basics from 'callbag-basics';
 
 const arr = Array(options.size)
   .fill(0)
@@ -25,23 +17,12 @@ const passthrough = <T>(_: any, x: T) => x;
 export const fold = new Suite(`scan -> scan ${options.size} integers`)
   .add(
     '@cycle/callbags',
-    runCallbags(pipe(fromArray(arr), scan(add, 0), scan(passthrough, 0))),
-    options
-  )
-  .add(
-    'callbag-basics',
-    runCallbagBasics(
-      basics.pipe(
-        fromArray(arr),
-        basics.scan(add, 0),
-        basics.scan(passthrough, 0)
-      )
-    ),
+    runCallbags(() => pipe(fromArray(arr), scan(add, 0), scan(passthrough, 0))),
     options
   )
   .add(
     'xstream',
-    runXStream(
+    runXStream(() =>
       xs
         .fromArray(arr)
         .fold(add, 0)
@@ -51,12 +32,14 @@ export const fold = new Suite(`scan -> scan ${options.size} integers`)
   )
   .add(
     'rxjs',
-    runRxJs(rxjsFrom(arr).pipe(rxjs.scan(add, 0), rxjs.scan(passthrough, 0))),
+    runRxJs(() =>
+      rxjsFrom(arr).pipe(rxjs.scan(add, 0), rxjs.scan(passthrough, 0))
+    ),
     options
   )
   .add(
     'most',
-    runMost(
+    runMost(() =>
       most
         .from(arr)
         .scan(add, 0)

--- a/perf/fold.ts
+++ b/perf/fold.ts
@@ -1,7 +1,6 @@
 import { Suite } from 'benchmark';
 import {
   options,
-  runSuite,
   runXStream,
   runCallbags,
   runCallbagBasics,
@@ -23,18 +22,11 @@ const arr = Array(options.size)
 const add = (x: number, y: number) => x + y;
 const passthrough = <T>(_: any, x: T) => x;
 
-const opts = {
-  defer: true,
-  onError: (e: any) => {
-    e.currentTarget.failure = e.error;
-  }
-};
-
-export const suite = new Suite(`scan -> scan ${options.size} integers`)
+export const fold = new Suite(`scan -> scan ${options.size} integers`)
   .add(
     '@cycle/callbags',
     runCallbags(pipe(fromArray(arr), scan(add, 0), scan(passthrough, 0))),
-    opts
+    options
   )
   .add(
     'callbag-basics',
@@ -45,7 +37,7 @@ export const suite = new Suite(`scan -> scan ${options.size} integers`)
         basics.scan(passthrough, 0)
       )
     ),
-    opts
+    options
   )
   .add(
     'xstream',
@@ -55,12 +47,12 @@ export const suite = new Suite(`scan -> scan ${options.size} integers`)
         .fold(add, 0)
         .fold(passthrough, 0)
     ),
-    opts
+    options
   )
   .add(
     'rxjs',
     runRxJs(rxjsFrom(arr).pipe(rxjs.scan(add, 0), rxjs.scan(passthrough, 0))),
-    opts
+    options
   )
   .add(
     'most',
@@ -70,7 +62,5 @@ export const suite = new Suite(`scan -> scan ${options.size} integers`)
         .scan(add, 0)
         .scan(passthrough, 0)
     ),
-    opts
+    options
   );
-
-runSuite(suite);

--- a/perf/fold.ts
+++ b/perf/fold.ts
@@ -1,0 +1,76 @@
+import { Suite } from 'benchmark';
+import {
+  options,
+  runSuite,
+  runXStream,
+  runCallbags,
+  runCallbagBasics,
+  runRxJs,
+  runMost
+} from './helpers';
+
+import { pipe, fromArray, scan } from '../src/index';
+import xs from 'xstream';
+import { from as rxjsFrom } from 'rxjs';
+import * as rxjs from 'rxjs/operators';
+import * as most from 'most';
+import * as basics from 'callbag-basics';
+
+const arr = Array(options.size)
+  .fill(0)
+  .map((_, i) => i);
+
+const add = (x: number, y: number) => x + y;
+const passthrough = <T>(_: any, x: T) => x;
+
+const opts = {
+  defer: true,
+  onError: (e: any) => {
+    e.currentTarget.failure = e.error;
+  }
+};
+
+export const suite = new Suite(`scan -> scan ${options.size} integers`)
+  .add(
+    '@cycle/callbags',
+    runCallbags(pipe(fromArray(arr), scan(add, 0), scan(passthrough, 0))),
+    opts
+  )
+  .add(
+    'callbag-basics',
+    runCallbagBasics(
+      basics.pipe(
+        fromArray(arr),
+        basics.scan(add, 0),
+        basics.scan(passthrough, 0)
+      )
+    ),
+    opts
+  )
+  .add(
+    'xstream',
+    runXStream(
+      xs
+        .fromArray(arr)
+        .fold(add, 0)
+        .fold(passthrough, 0)
+    ),
+    opts
+  )
+  .add(
+    'rxjs',
+    runRxJs(rxjsFrom(arr).pipe(rxjs.scan(add, 0), rxjs.scan(passthrough, 0))),
+    opts
+  )
+  .add(
+    'most',
+    runMost(
+      most
+        .from(arr)
+        .scan(add, 0)
+        .scan(passthrough, 0)
+    ),
+    opts
+  );
+
+runSuite(suite);

--- a/perf/helpers.ts
+++ b/perf/helpers.ts
@@ -3,7 +3,6 @@ import { Stream } from 'xstream';
 import { subscribe, Source } from '../src/index';
 import { Observable } from 'rxjs';
 import * as most from 'most';
-import * as basics from 'callbag-basics';
 
 export const options = {
   size: 1000000
@@ -77,15 +76,7 @@ export function runCallbags(source: Source<any>): (fn: any) => void {
 }
 
 export function runCallbagBasics(source: any): (fn: any) => void {
-  return f =>
-    source(0, (t: any, d: any) => {
-      if (t === 2 && !d) {
-        f.resolve();
-      } else if (t === 2) {
-        f.benchmark.emit({ type: 'error', error: d });
-        f.resolve(d);
-      }
-    });
+  return f => subscribe(mkObserver(f))(source);
 }
 
 export function runRxJs(observable: Observable<any>): (fn: any) => void {

--- a/perf/helpers.ts
+++ b/perf/helpers.ts
@@ -5,7 +5,11 @@ import { Observable } from 'rxjs';
 import * as most from 'most';
 
 export const options = {
-  size: 1000000
+  size: 1000000,
+  defer: true,
+  onError: (e: any) => {
+    e.currentTarget.failure = e.error;
+  }
 };
 
 const noop = () => {};

--- a/perf/helpers.ts
+++ b/perf/helpers.ts
@@ -1,0 +1,97 @@
+import { Suite } from 'benchmark';
+import { Stream } from 'xstream';
+import { subscribe, Source } from '../src/index';
+import { Observable } from 'rxjs';
+import * as most from 'most';
+import * as basics from 'callbag-basics';
+
+export const options = {
+  size: 1000000
+};
+
+const noop = () => {};
+
+function line(): string {
+  return Array(53)
+    .fill('-')
+    .join('');
+}
+
+function padr(n: number, s: string): string {
+  return Array(Math.max(n - s.length, 0))
+    .fill(' ')
+    .concat(s)
+    .join('');
+}
+
+function padl(n: number, s: string): string {
+  return (
+    s +
+    Array(Math.max(n - s.length, 0))
+      .fill(' ')
+      .join('')
+  );
+}
+
+export function runSuite(s: Suite): void {
+  s.on('start', function(this: any) {
+    console.log(this.name);
+    console.log(line());
+  })
+    .on('cycle', function(event: any) {
+      const t = event.target;
+      if (t.failure) {
+        console.error(`${padl(16, t.name)}FAILED: ${t.failure}`);
+      } else {
+        const result =
+          padl(16, t.name) +
+          padr(13, t.hz.toFixed(2) + ' op/s') +
+          ' \xb1' +
+          padr(7, t.stats.rme.toFixed(2) + '%') +
+          padr(15, ` (${t.stats.sample.length} samples)`);
+
+        console.log(result);
+      }
+    })
+    .on('complete', () => console.log(line()))
+    .run();
+}
+
+function mkObserver(deffered: any) {
+  return {
+    next: noop,
+    complete: () => deffered.resolve(),
+    error: (e: any) => {
+      deffered.benchmark.emit({ type: 'error', error: e });
+      deffered.resolve(e);
+    }
+  };
+}
+
+export function runXStream(stream: Stream<any>): (fn: any) => void {
+  return f => stream.addListener(mkObserver(f));
+}
+
+export function runCallbags(source: Source<any>): (fn: any) => void {
+  return f => subscribe(mkObserver(f))(source);
+}
+
+export function runCallbagBasics(source: any): (fn: any) => void {
+  return f =>
+    source(0, (t: any, d: any) => {
+      if (t === 2 && !d) {
+        f.resolve();
+      } else if (t === 2) {
+        f.benchmark.emit({ type: 'error', error: d });
+        f.resolve(d);
+      }
+    });
+}
+
+export function runRxJs(observable: Observable<any>): (fn: any) => void {
+  return f => observable.subscribe(mkObserver(f));
+}
+
+export function runMost(stream: most.Stream<any>): (fn: any) => void {
+  return f => stream.subscribe(mkObserver(f));
+}

--- a/perf/index.ts
+++ b/perf/index.ts
@@ -1,4 +1,8 @@
 import { runSuite } from './helpers';
 import { fold } from './fold';
+import { dataflow } from './dataflow';
 
-[fold].forEach(runSuite);
+[fold, dataflow].reduce(
+  (acc, curr) => acc.then(() => runSuite(curr)),
+  Promise.resolve()
+);

--- a/perf/index.ts
+++ b/perf/index.ts
@@ -1,0 +1,4 @@
+import { runSuite } from './helpers';
+import { fold } from './fold';
+
+[fold].forEach(runSuite);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,14 +1,20 @@
 devDependencies:
   '@types/assert': 1.4.4
+  '@types/benchmark': 1.0.31
   '@types/mocha': 5.2.7
   assert: 2.0.0
+  benchmark: github.com/bestiejs/benchmark.js/42f3b732bac3640eddb3ae5f50e445f3141016fd
+  callbag-basics: 3.2.0
   fast-check: 1.21.0
   mocha: 7.0.1
+  most: 1.8.0_most@1.8.0
   nyc: 15.0.0
   prettier: 1.19.1
   rollup: 1.29.1
+  rxjs: 6.5.4
   ts-node: 8.6.2_typescript@3.7.5
   typescript: 3.7.5
+  xstream: 11.11.0
 lockfileVersion: 5.1
 packages:
   /@babel/code-frame/7.8.3:
@@ -138,10 +144,27 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
+  /@most/multicast/1.3.0_most@1.8.0:
+    dependencies:
+      '@most/prelude': 1.7.3
+      most: 1.8.0_most@1.8.0
+    dev: true
+    peerDependencies:
+      most: ^1.0.1
+    resolution:
+      integrity: sha512-DWH8AShgp5bXn+auGzf5tzPxvpmEvQJd0CNsApOci1LDF4eAEcnw4HQOr2Jaa+L92NbDYFKBSXxll+i7r1ikvw==
+  /@most/prelude/1.7.3:
+    dev: true
+    resolution:
+      integrity: sha512-qWWEnA22UP1lzFfKx75XMut6DUUXGRKe7qv2k+Bgs7ju8lwb5RjsZYyQZ+VcsYvHcIavHKzseLlBMLOe2CvUZw==
   /@types/assert/1.4.4:
     dev: true
     resolution:
       integrity: sha512-oA2uyvd1aiPbJNSEvREhJk92NYIKvt3MAg0rENZyxKrCN0NFkxtRMC6IN5ytXK+Ri/ALJtex+btq4QUnzWGoYg==
+  /@types/benchmark/1.0.31:
+    dev: true
+    resolution:
+      integrity: sha512-F6fVNOkGEkSdo/19yWYOwVKGvzbTeWkR/XQYBKtGBQ9oGRjBN9f/L4aJI4sDcVPJO58Y1CJZN8va9V2BhrZapA==
   /@types/color-name/1.1.1:
     dev: true
     resolution:
@@ -299,6 +322,129 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==
+  /callbag-basics/3.2.0:
+    dependencies:
+      callbag: 1.2.0
+      callbag-combine: 1.2.0
+      callbag-concat: 1.2.1
+      callbag-filter: 1.1.0
+      callbag-flatten: 1.4.0
+      callbag-for-each: 1.1.0
+      callbag-from-event: 1.2.1
+      callbag-from-iter: 1.2.0
+      callbag-from-obs: 1.2.0
+      callbag-from-promise: 1.3.0
+      callbag-interval: 1.1.0
+      callbag-map: 1.1.0
+      callbag-merge: 2.0.1
+      callbag-pipe: 1.2.0
+      callbag-scan: 1.1.0
+      callbag-share: 1.2.0
+      callbag-skip: 1.1.0
+      callbag-take: 1.4.0
+    dev: true
+    resolution:
+      integrity: sha512-+wOwoQYvn+R9q6H/co0KP05pSL4dIQGWvz3BHSshRBf17Y8P8gr7H4kZdvUl7SJ5d0raa97mHfb4ZJRyvReynw==
+  /callbag-combine/1.2.0:
+    dependencies:
+      callbag: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-iDHfGNcBb9oIJLA//ytxU1e1W5MjjG+lIu2E2xtVs8fBba7+Zkp4wU6bnIf5II34hDxyEy8O8ct8TY6GO/W8Ig==
+  /callbag-concat/1.2.1:
+    dependencies:
+      callbag: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-iIC4FCUF7sKnt4gDKHNjMRHekebdaA1/udjON/mCLg31EzzTO/dE9nfxpcj+G/63KopFXVQdZKQDsu7UOYGpPg==
+  /callbag-filter/1.1.0:
+    dependencies:
+      callbag: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-m6ZHEd9JYHBAYJAdeqgt3gIKSoZOizfJTxIPd8EvDwY8Dr44+slm090WvCrrlz2SZoU8mCqpmZ8TFrGKXHo/yw==
+  /callbag-flatten/1.4.0:
+    dependencies:
+      callbag: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-2JM/jA0Ijnuu15kqcdepVd8Iv/L3VytTFOjP0rk/BKc4/yvUUPkQfR3U2QM6Uq+DO/roOWMfrVKaMAxsZ8ciww==
+  /callbag-for-each/1.1.0:
+    dependencies:
+      callbag: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-/FKC/dd3hnw/M1G5mlZrz/+UbtHYPz5PsmmBvpthNb67v6XuQlT93BzxQDxRHAalAjsOci8ZqoYFgmmJxwGhvg==
+  /callbag-from-event/1.2.1:
+    dependencies:
+      callbag: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-rFZoDPqyjSxMSe2ikAfjxa76GhnTg16H36yNJNyPdrbsRvP2bYVGs32N+ddzB9qsnIBzJlwhgiHOv9Uav0HHXg==
+  /callbag-from-iter/1.2.0:
+    dev: true
+    resolution:
+      integrity: sha512-9rWvHOnRGp01YMRHHwgVZOO1vu4IRR8GcoH3FpSB16AMzum5juFWJPCMX/XnkJ9j6cic/G+kvb1Grvi6IuSmIQ==
+  /callbag-from-obs/1.2.0:
+    dependencies:
+      symbol-observable: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-InhdPC6P4Gdpg7nuXSkocDFlb+//sbwCrVCYhxOHhSVm1gDcw/zSA+IF1gHdYtk4RQKKaCymUFCkVVUVSRThVQ==
+  /callbag-from-promise/1.3.0:
+    dependencies:
+      callbag: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-1e6Xloc5DavrPUYIUKUNLhYTTXFtrRH/tN0qbS+LAzNeu9whCJOLEExjVfntEfSbiuADClAuIiVDLRiPBhu1mg==
+  /callbag-interval/1.1.0:
+    dependencies:
+      callbag: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-xkYj7t/l9+GaP0kvPi6LadF3ZNSiQAhbEzwnnTrDB/UtkBCrzKPZ9Kiti8P8oHYxL2jGEuRWi86PD3uM7qXLbg==
+  /callbag-map/1.1.0:
+    dependencies:
+      callbag: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-/xFzvJCtx1xulZpFeI4wq+ZD7tkg417XOeJ3wS9v8bHLLpt+fHKXgbZ8TBnnIxywJN6Uu/ZhL+c1DzUG6KXYFQ==
+  /callbag-merge/2.0.1:
+    dev: true
+    resolution:
+      integrity: sha512-Kl6JQ8Swc7DBuIL+Yjkgm92l82vrD2yQCNZHO8M8o6zVI+a0/RAAPLD5qrnGA1WwHLOOD6xAYsm0gzfzAJ3hkA==
+  /callbag-pipe/1.2.0:
+    dev: true
+    resolution:
+      integrity: sha512-M+LdHUK0qJkm4CRe+I870ZzD/SnzcpTsfJRzFoB2hOkNXlrVdoj002KMkfdS4pHMfV6egzZFd8j+xJu6C4kwEQ==
+  /callbag-scan/1.1.0:
+    dependencies:
+      callbag: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-5Aw9LR8b4Fg/gC++lWrq9sXEqgO0c5Gk+HWaFhFoVqgujSUVRxFw+c4bLw1eExWrBX6OeBDbVZ/2rMr/E0q9cQ==
+  /callbag-share/1.2.0:
+    dependencies:
+      callbag: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-Gt+D5lfJ/j3X5/3PiMPL8hHDPBmeQILZl2QYu+YJtSFz6PlNGQSL45aD4e4uoxMvhMZY9NpMHh7KRWia9PZA+g==
+  /callbag-skip/1.1.0:
+    dependencies:
+      callbag: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-KodTVJFA1h1Z7iFvs2ocwtyvb+q38i/FJTabdMTmmPucQV+XpGH8e6BYxmYRznY4FQUTLM9e5Y5HqbUxT7ma1w==
+  /callbag-take/1.4.0:
+    dependencies:
+      callbag: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-SMN236uYqjZ+8ypAY12qkV2QwutjOe96GyYPzUF9RKKJR5nRyu0fON4r4XBZ3ZonOWnDW05CWmKmS0mVQg5TIg==
+  /callbag/1.2.0:
+    dev: true
+    resolution:
+      integrity: sha512-RMcVOk2oyA8CyCt/HsLEvnvvttKlaGVaG0uOo5IY7RpdiPLhStjxv5oYre33VJfT8kJE+cuKLSNHooz7yCUdhQ==
   /camelcase/5.3.1:
     dev: true
     engines:
@@ -1023,6 +1169,16 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-9eWmWTdHLXh72rGrdZjNbG3aa1/3NRPpul1z0D979QpEnFdCG0Q5tv834N+94QEN2cysfV72YocQ3fn87s70fg==
+  /most/1.8.0_most@1.8.0:
+    dependencies:
+      '@most/multicast': 1.3.0_most@1.8.0
+      '@most/prelude': 1.7.3
+      symbol-observable: 1.2.0
+    dev: true
+    peerDependencies:
+      most: '*'
+    resolution:
+      integrity: sha512-V49VlfnnGBVSIcHVeW6jViOwsPwSdnw8qv2BQ97TCfJMA07Yq5BkjUnEPmDZ0Kqm6crTBlgmdnH+jO0qVJMXfw==
   /ms/2.1.1:
     dev: true
     resolution:
@@ -1232,6 +1388,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  /platform/1.3.5:
+    dev: true
+    resolution:
+      integrity: sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==
   /prettier/1.19.1:
     dev: true
     engines:
@@ -1305,6 +1465,14 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-dGQ+b9d1FOX/gluiggTAVnTvzQZUEkCi/TwZcax7ujugVRHs0nkYJlV9U4hsifGEMojnO+jvEML2CJQ6qXgbHA==
+  /rxjs/6.5.4:
+    dependencies:
+      tslib: 1.10.0
+    dev: true
+    engines:
+      npm: '>=2.0.0'
+    resolution:
+      integrity: sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
   /safe-buffer/5.1.2:
     dev: true
     resolution:
@@ -1488,6 +1656,12 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  /symbol-observable/1.2.0:
+    dev: true
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
   /test-exclude/6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.2
@@ -1625,6 +1799,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==
+  /xstream/11.11.0:
+    dependencies:
+      symbol-observable: 1.2.0
+    dev: true
+    resolution:
+      integrity: sha512-0zF3PLsHrmbToPBgX1jYZFNw+t5octSFJgVRH44HGlGBBjY7gscvDQOZvty8IQV15Snia1RcLPECWDfEaE4aXg==
   /y18n/4.0.0:
     dev: true
     resolution:
@@ -1692,14 +1872,30 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+  github.com/bestiejs/benchmark.js/42f3b732bac3640eddb3ae5f50e445f3141016fd:
+    dependencies:
+      lodash: 4.17.15
+      platform: 1.3.5
+    dev: true
+    name: benchmark
+    resolution:
+      registry: 'https://registry.npmjs.org/'
+      tarball: 'https://codeload.github.com/bestiejs/benchmark.js/tar.gz/42f3b732bac3640eddb3ae5f50e445f3141016fd'
+    version: 2.1.4
 specifiers:
   '@types/assert': ^1.4.4
+  '@types/benchmark': ^1.0.31
   '@types/mocha': ^5.2.7
   assert: ^2.0.0
+  benchmark: 'github:bestiejs/benchmark.js#42f3b732bac3640eddb3ae5f50e445f3141016fd'
+  callbag-basics: ^3.2.0
   fast-check: ^1.21.0
   mocha: ^7.0.1
+  most: ^1.8.0
   nyc: ^15.0.0
   prettier: ^1.19.1
   rollup: ^1.29.1
+  rxjs: ^6.5.4
   ts-node: ^8.6.2
   typescript: ^3.7.5
+  xstream: ^11.11.0

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,0 @@
-export const undef = Symbol('undef');

--- a/src/map.ts
+++ b/src/map.ts
@@ -1,5 +1,4 @@
 import { Operator } from './types';
-import { undef } from './constants';
 
 export function map<A, B>(f: (a: A) => B): Operator<A, B> {
   return source => (_, sink) => {
@@ -13,15 +12,19 @@ export function scan<A, B>(
   f: (accumulator: B, current: A) => B,
   start?: B
 ): Operator<A, B> {
+  let hasAcc = arguments.length === 2;
   return source => (_, sink) => {
-    let acc: any = arguments.length === 2 ? start : undef;
+    let acc: any = start;
     source(0, (t, d) => {
       if (t === 0) {
         sink(t, d);
-        if (acc !== undef) sink(1, acc);
+        if (hasAcc) sink(1, acc);
       } else if (t === 1) {
-        if (acc === undef) acc = d;
-        else acc = f(acc, d);
+        if (hasAcc) acc = f(acc, d);
+        else {
+          hasAcc = true;
+          acc = d;
+        }
 
         sink(1, acc);
       } else sink(t, d);

--- a/src/skip.ts
+++ b/src/skip.ts
@@ -1,5 +1,4 @@
 import { Operator } from './types';
-import { undef } from './constants';
 
 export function skip<T>(n: number): Operator<T, T> {
   return source => (_, sink) => {
@@ -13,11 +12,11 @@ export function skip<T>(n: number): Operator<T, T> {
 
 export function last<T>(): Operator<T, T> {
   return source => (_, sink) => {
-    let last: any = undef;
+    let last: any[] = [];
 
     source(0, (t, d) => {
-      if (t === 1) last = d;
-      else if (t === 2 && last !== undef) sink(1, last);
+      if (t === 1) last[0] = d;
+      else if (t === 2 && last.length > 0) sink(1, last[0]);
       if (t !== 1) sink(t, d);
     });
   };


### PR DESCRIPTION
For `scan`:
```
scan -> scan 1000000 integers
-----------------------------------------------------
@cycle/callbags    25.00 op/s ±  1.15%   (61 samples)
callbag-basics     26.37 op/s ±  1.14%   (65 samples)
xstream            13.99 op/s ±  1.16%   (67 samples)
rxjs               15.20 op/s ±  1.79%   (73 samples)
most               28.18 op/s ±  1.77%   (67 samples)
-----------------------------------------------------
```