### PR TITLE
Do not emit value from startWith after immediate (sync) disposal from the consumer

### DIFF
--- a/src/startWith.ts
+++ b/src/startWith.ts
@@ -1,10 +1,15 @@
-import { Operator } from './types';
+import { Operator, END } from './types';
 
 export function startWith<T>(value: T): Operator<T, T> {
   return source => (_, sink) => {
+    let ended = false;
     source(0, (t, d) => {
       if (t === 0) {
-        sink(0, d);
+        sink(0, (_: END) => {
+          ended = true;
+          d(2);
+        });
+        if (ended) return;
         sink(1, value);
       } else sink(t, d);
     });

--- a/test/startWith.ts
+++ b/test/startWith.ts
@@ -48,4 +48,21 @@ describe('startWith', () => {
       })
     );
   });
+
+  it('should not deliver value after synchronous disposal', () => {
+    let taken = 0;
+
+    pipe(fromPromise(new Promise(() => {})), startWith('foo'), source => {
+      source(0, (t, d) => {
+        if (t === 0) {
+          d(2);
+          return;
+        }
+        taken++;
+      });
+      return () => {};
+    });
+
+    assert.strictEqual(taken, 0);
+  });
 });


### PR DESCRIPTION
Similar to https://github.com/cyclejs/callbags/pull/13