### PR TITLE
Do not pass sampler error to the source

### DIFF
--- a/src/sample.ts
+++ b/src/sample.ts
@@ -34,7 +34,7 @@ export function sampleWith<T, R, U>(
         if (d) {
           errored = true;
           sink(t, d);
-          talkback?.(t, d);
+          talkback?.(t);
         }
       }
     });


### PR DESCRIPTION
I'm not entirely sure about this change and that's also why I haven't added a test for this yet.

It seems that the source can never react anyhow to an error and other operators (such as `flatten`) dont propagate this info to sources, so I think this could (should?) be skipped here.