### PR TITLE
Add replay subject

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ export { fromArray, fromPromise, from, of } from './from';
 export { throwError } from './throwError';
 export { merge } from './merge';
 export { combineWith, combine } from './combine';
-export { makeSubject } from './subject';
+export { makeSubject, makeReplaySubject } from './subject';
 
 // Operators
 export { map, scan } from './map';

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -25,3 +25,42 @@ export function makeSubject<T>(): Subject<T> {
     }
   };
 }
+
+export function makeReplaySubject<T>(numReplays = 1): Subject<T> {
+  let sinks: Array<StrictSink<T> | undefined> = [];
+  let buffer: Array<T> | undefined = [];
+  let replays = 0;
+
+  return (type: ALL, data: unknown) => {
+    if (type === 0) {
+      const sink = data as StrictSink<T>;
+      sinks.push(sink);
+      sink(0, () => {
+        const i = sinks.indexOf(sink);
+        sinks[i] = void 0;
+      });
+      if (buffer) {
+        for (const x of buffer) {
+          sink(1, x);
+        }
+        if (++replays >= numReplays) {
+          buffer = void 0;
+        }
+      }
+    } else {
+      let hasDeleted = false;
+
+      if (buffer && type === 1) {
+        buffer.push(data as T);
+      }
+      for (let i = 0; i < sinks.length; i++) {
+        if (sinks[i]) sinks[i]!(type, data);
+        else hasDeleted = true;
+      }
+
+      if (hasDeleted) {
+        sinks = sinks.filter(x => x !== undefined);
+      }
+    }
+  };
+}

--- a/test/replaySubject.ts
+++ b/test/replaySubject.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import { unsubscribeEarly } from './helpers';
 
 import { pipe, makeReplaySubject, subscribe } from '../src/index';
 
@@ -29,7 +28,7 @@ describe('makeReplaySubject', () => {
     assert.deepStrictEqual(res, [1, 2, 3, 4, 5, 6]);
   });
 
-  it('should deliver data two second listener after buffer is deleted', () => {
+  it('should deliver data to second listener after buffer is deleted', () => {
     const subject = makeReplaySubject<number>(2);
 
     for (const x of [1, 2, 3, 4, 5]) {
@@ -57,7 +56,7 @@ describe('makeReplaySubject', () => {
           res2.push(d);
         },
         e => {
-          if (e) assert.fail('shoudl not terminate with error');
+          if (e) assert.fail('should not terminate with error');
         }
       )
     );
@@ -74,7 +73,7 @@ describe('makeReplaySubject', () => {
           res3.push(d);
         },
         e => {
-          if (e) assert.fail('shoudl not terminate with error');
+          if (e) assert.fail('should not terminate with error');
         }
       )
     );

--- a/test/replaySubject.ts
+++ b/test/replaySubject.ts
@@ -1,0 +1,88 @@
+import * as assert from 'assert';
+import { unsubscribeEarly } from './helpers';
+
+import { pipe, makeReplaySubject, subscribe } from '../src/index';
+
+describe('makeReplaySubject', () => {
+  it('should deliver data if subscribed afterwards', () => {
+    const subject = makeReplaySubject<number>();
+
+    for (const x of [1, 2, 3, 4, 5]) {
+      subject(1, x);
+    }
+
+    let res: any[] = [];
+    pipe(
+      subject,
+      subscribe(
+        d => {
+          res.push(d);
+        },
+        e => {
+          if (e) assert.fail('should not terminate with error');
+        }
+      )
+    );
+
+    subject(1, 6);
+
+    assert.deepStrictEqual(res, [1, 2, 3, 4, 5, 6]);
+  });
+
+  it('should deliver data two second listener after buffer is deleted', () => {
+    const subject = makeReplaySubject<number>(2);
+
+    for (const x of [1, 2, 3, 4, 5]) {
+      subject(1, x);
+    }
+
+    let res: any[] = [];
+    pipe(
+      subject,
+      subscribe(
+        d => {
+          res.push(d);
+        },
+        e => {
+          if (e) assert.fail('should not terminate with error');
+        }
+      )
+    );
+
+    let res2: any[] = [];
+    pipe(
+      subject,
+      subscribe(
+        d => {
+          res2.push(d);
+        },
+        e => {
+          if (e) assert.fail('shoudl not terminate with error');
+        }
+      )
+    );
+
+    // buffer is deleted here
+
+    subject(1, 6);
+
+    let res3: any[] = [];
+    pipe(
+      subject,
+      subscribe(
+        d => {
+          res3.push(d);
+        },
+        e => {
+          if (e) assert.fail('shoudl not terminate with error');
+        }
+      )
+    );
+
+    subject(1, 7);
+
+    assert.deepStrictEqual(res, [1, 2, 3, 4, 5, 6, 7]);
+    assert.deepStrictEqual(res2, [1, 2, 3, 4, 5, 6, 7]);
+    assert.deepStrictEqual(res3, [7]);
+  });
+});

--- a/test/subject.ts
+++ b/test/subject.ts
@@ -1,11 +1,17 @@
 import * as assert from 'assert';
 import { unsubscribeEarly } from './helpers';
 
-import { pipe, makeSubject, subscribe } from '../src/index';
+import {
+  pipe,
+  makeSubject,
+  makeReplaySubject,
+  subscribe,
+  Subject
+} from '../src/index';
 
-describe('makeSubject', () => {
-  it('should allow sinks to unsubscribe', () => {
-    const subject = makeSubject<number>();
+function makeUnsubscribeTest(fn: () => Subject<number>) {
+  return () => {
+    const subject = fn();
 
     pipe(
       subject,
@@ -21,5 +27,13 @@ describe('makeSubject', () => {
     for (const x of [1, 2, 3, 4, 5]) {
       subject(1, x);
     }
-  });
+  };
+}
+
+describe('makeSubject', () => {
+  it('should allow sinks to unsubscribe', makeUnsubscribeTest(makeSubject));
+  it(
+    'should allow sinks to unsubscribe (replaySubject)',
+    makeUnsubscribeTest(makeReplaySubject)
+  );
 });

--- a/test/subscribe.ts
+++ b/test/subscribe.ts
@@ -1,13 +1,7 @@
 import * as assert from 'assert';
 
 import { interval } from 'callbag-basics';
-import {
-  subscribe,
-  of,
-  throwError,
-  pipe,
-  Producer,
-} from '../src/index';
+import { subscribe, of, throwError, pipe, Producer } from '../src/index';
 
 describe('subscribe tests', () => {
   it('should call onEnd() with an error argument when it fails', () => {


### PR DESCRIPTION
This is needed for `@cycle/run` where we need to buffer synchronous emissions to the API subjects