### PR TITLE
Prevent packaging unnecessary files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+perf/
+test/
+.nyc_output/
+coverage/
+
+*.log


### PR DESCRIPTION
Having tests in the package is unnecessary. I'd leave the sources in because they might be interesting for a quick look at the source code