### PR TITLE
Add onDispose() callback to subscribe

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,4 +1,4 @@
-import { Operator } from './types';
+import { Operator, END } from './types';
 
 export function uponStart<T>(fn: () => void): Operator<T, T> {
   return source => (_, sink) => {
@@ -12,8 +12,15 @@ export function uponStart<T>(fn: () => void): Operator<T, T> {
 export function uponEnd<T>(fn: (d?: any) => void): Operator<T, T> {
   return source => (_, sink) => {
     source(0, (t, d) => {
-      if (t === 2) fn(d);
-      sink(t, d);
+      if (t === 0) {
+        sink(t, (_: END, err: any) => {
+          fn(err);
+          d(2, err);
+        });
+      } else {
+        if (t === 2) fn(d);
+        sink(t, d);
+      }
     });
   };
 }

--- a/src/subscribe.ts
+++ b/src/subscribe.ts
@@ -16,9 +16,9 @@ export function subscribe<T>(
       if (t === 2) onEnd?.(d);
     });
     return () => {
-      onEnd?.();
       if (talkback) talkback(2);
       else disposeLater = true;
+      onEnd?.();
     };
   };
 }

--- a/src/subscribe.ts
+++ b/src/subscribe.ts
@@ -2,7 +2,8 @@ import { Consumer, Talkback } from './types';
 
 export function subscribe<T>(
   onData: (t: T) => void,
-  onEnd?: (e?: any) => void
+  onEnd?: (e?: any) => void,
+  onDispose?: () => void
 ): Consumer<T> {
   return source => {
     let talkback: Talkback | undefined;
@@ -18,7 +19,7 @@ export function subscribe<T>(
     return () => {
       if (talkback) talkback(2);
       else disposeLater = true;
-      onEnd?.();
+      onDispose?.();
     };
   };
 }

--- a/src/subscribe.ts
+++ b/src/subscribe.ts
@@ -16,6 +16,7 @@ export function subscribe<T>(
       if (t === 2) onEnd?.(d);
     });
     return () => {
+      onEnd?.();
       if (talkback) talkback(2);
       else disposeLater = true;
     };

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -84,21 +84,14 @@ describe('hooks', () => {
 
   it('uponEnd should be called when the stream is disposed', () => {
     let effect = false;
-    let completed = false;
     const dispose = pipe(
       never(),
       uponEnd(() => {
         effect = true;
       }),
-      subscribe(
-        () => assert.fail('should not deliver data'),
-        () => {
-          assert.strictEqual(effect, true);
-          completed = true;
-        }
-      )
+      subscribe(() => assert.fail('should not deliver data'))
     );
     dispose();
-    assert.strictEqual(completed, true);
+    assert.strictEqual(effect, true);
   });
 });

--- a/test/hooks.ts
+++ b/test/hooks.ts
@@ -7,7 +7,8 @@ import {
   pipe,
   subscribe,
   of,
-  throwError
+  throwError,
+  never
 } from '../src/index';
 
 describe('hooks', () => {
@@ -70,7 +71,7 @@ describe('hooks', () => {
         effect = true;
       }),
       subscribe(
-        d => assert.strictEqual(d, 5),
+        () => assert.fail('should not deliver data'),
         e => {
           assert.strictEqual(e, 'myError');
           assert.strictEqual(effect, true);
@@ -78,6 +79,26 @@ describe('hooks', () => {
         }
       )
     );
+    assert.strictEqual(completed, true);
+  });
+
+  it('uponEnd should be called when the stream is disposed', () => {
+    let effect = false;
+    let completed = false;
+    const dispose = pipe(
+      never(),
+      uponEnd(() => {
+        effect = true;
+      }),
+      subscribe(
+        () => assert.fail('should not deliver data'),
+        () => {
+          assert.strictEqual(effect, true);
+          completed = true;
+        }
+      )
+    );
+    dispose();
     assert.strictEqual(completed, true);
   });
 });

--- a/test/subscribe.ts
+++ b/test/subscribe.ts
@@ -25,17 +25,21 @@ describe('subscribe tests', () => {
     const FIRST = 40; // when dispose is called
     const SECOND = 80; // when source *would* deliver data
     const THIRD = 120; // when final asserts are done
+    let completed = 0;
 
     const dispose = pipe(
       interval(SECOND) as Producer<number>,
       subscribe(
         () => assert.fail('data should not be delivered after dispose'),
-        () => assert.fail('termination should not occur after dispose')
+        () => completed++
       )
     );
     assert.strictEqual(typeof dispose, 'function');
     setTimeout(dispose, FIRST);
-    setTimeout(done, THIRD);
+    setTimeout(() => {
+      assert.strictEqual(completed, 1);
+      done();
+    }, THIRD);
   });
 
   describe('dispose()', () => {
@@ -58,17 +62,52 @@ describe('subscribe tests', () => {
         }, THIRD);
       };
 
+      let completed = 0;
       const dispose = pipe(
         source,
         subscribe(
           () => assert.fail('data should not be delivered after dispose'),
-          () => assert.fail('termination should not occur')
+          () => completed++
         )
       );
       assert.strictEqual(typeof dispose, 'function');
       setTimeout(dispose, FIRST);
       setTimeout(() => {
-        assert.equal(talkbackCalled, true);
+        assert.strictEqual(talkbackCalled, true);
+        assert.strictEqual(completed, 1);
+        done();
+      }, FOURTH);
+    });
+
+    it('works without complete() function', done => {
+      const FIRST = 50; // when dispose is called
+      const SECOND = 100; // when source starts listening to sink
+      const THIRD = 200; // when source *would* deliver data
+      const FOURTH = 300; // when final asserts are done
+
+      let talkbackCalled = false;
+      const source = (_: 0, sink: any) => {
+        setTimeout(() => {
+          sink(0, () => {
+            talkbackCalled = true;
+            clearTimeout(timeout);
+          });
+        }, SECOND);
+        let timeout = setTimeout(() => {
+          sink(1, 42);
+        }, THIRD);
+      };
+
+      const dispose = pipe(
+        source,
+        subscribe(() =>
+          assert.fail('data should not be delivered after dispose')
+        )
+      );
+      assert.strictEqual(typeof dispose, 'function');
+      setTimeout(dispose, FIRST);
+      setTimeout(() => {
+        assert.strictEqual(talkbackCalled, true);
         done();
       }, FOURTH);
     });

--- a/test/subscribe.ts
+++ b/test/subscribe.ts
@@ -25,19 +25,20 @@ describe('subscribe tests', () => {
     const FIRST = 40; // when dispose is called
     const SECOND = 80; // when source *would* deliver data
     const THIRD = 120; // when final asserts are done
-    let completed = 0;
+    let disposed = 0;
 
     const dispose = pipe(
       interval(SECOND) as Producer<number>,
       subscribe(
         () => assert.fail('data should not be delivered after dispose'),
-        () => completed++
+        () => assert.fail('should not complete after dispose'),
+        () => disposed++
       )
     );
     assert.strictEqual(typeof dispose, 'function');
     setTimeout(dispose, FIRST);
     setTimeout(() => {
-      assert.strictEqual(completed, 1);
+      assert.strictEqual(disposed, 1);
       done();
     }, THIRD);
   });
@@ -62,19 +63,20 @@ describe('subscribe tests', () => {
         }, THIRD);
       };
 
-      let completed = 0;
+      let disposed = 0;
       const dispose = pipe(
         source,
         subscribe(
           () => assert.fail('data should not be delivered after dispose'),
-          () => completed++
+          () => assert.fail('should not complete after dispose'),
+          () => disposed++
         )
       );
       assert.strictEqual(typeof dispose, 'function');
       setTimeout(dispose, FIRST);
       setTimeout(() => {
         assert.strictEqual(talkbackCalled, true);
-        assert.strictEqual(completed, 1);
+        assert.strictEqual(disposed, 1);
         done();
       }, FOURTH);
     });


### PR DESCRIPTION
This is something I found when porting over the tests for  `setupReusable`