### PR TITLE
Fix async subject

### DIFF
--- a/src/subject.ts
+++ b/src/subject.ts
@@ -55,7 +55,11 @@ export function makeAsyncSubject<T>(): Subject<T> {
         sinks = sinks.filter(Boolean);
       }
 
-      promise = void 0;
+      if (bufferLength > 0) {
+        promise = scheduleData();
+      } else {
+        promise = void 0;
+      }
     });
 
   return (type: ALL, data: unknown) => {

--- a/test/asyncSubject.ts
+++ b/test/asyncSubject.ts
@@ -68,4 +68,26 @@ describe('makeAsyncSubject', () => {
 
     assert.strictEqual(completed, 2);
   });
+
+  it.only('should deliver data that is emitted sync while delivering earlier data', done => {
+    const subject = makeAsyncSubject();
+    const expected = [0, 1];
+
+    pipe(
+      subject,
+      subscribe(d => {
+        assert.strictEqual(d, expected.shift());
+        if (d === 0) {
+          subject(1, 1);
+        }
+      })
+    );
+
+    subject(1, 0);
+
+    setTimeout(() => {
+      assert.strictEqual(expected.length, 0);
+      done();
+    }, 10);
+  });
 });

--- a/test/asyncSubject.ts
+++ b/test/asyncSubject.ts
@@ -69,7 +69,7 @@ describe('makeAsyncSubject', () => {
     assert.strictEqual(completed, 2);
   });
 
-  it.only('should deliver data that is emitted sync while delivering earlier data', done => {
+  it('should deliver data that is emitted sync while delivering earlier data', done => {
     const subject = makeAsyncSubject();
     const expected = [0, 1];
 


### PR DESCRIPTION
I just found a bug while doing the `@cycle/state` tests. If we emit more data synchronously, we do not trigger another promise to deliver said data. I did not push the first commit separately, but I made sure the test failed without the fix