### PR TITLE
feat: Add debug operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Currently, the following set of operators is implemented, others might follow. N
 
 - [`map`](./src/map.ts)
 - [`scan`](./src/map.ts)
+- [`debug`](./src/map.ts)
 - [`take`](./src/take.ts)
 - [`first`](./src/take.ts)
 - [`filter`](./src/filter.ts)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export { makeSubject, makeAsyncSubject } from './subject';
 export { create, never, empty, throwError } from './identities';
 
 // Operators
-export { map, scan } from './map';
+export { map, scan, debug } from './map';
 export { take, first } from './take';
 export { filter } from './filter';
 export { startWith } from './startWith';
@@ -32,5 +32,5 @@ export {
   ALL,
   START,
   DATA,
-  END
+  END,
 } from './types';

--- a/src/map.ts
+++ b/src/map.ts
@@ -31,3 +31,11 @@ export function scan<A, B>(
     });
   };
 }
+
+export function debug<A>(msg: string | ((a: A) => void)): Operator<A, A> {
+  const f = typeof msg === 'function' ? msg : (x: A) => console.log(msg, x);
+  return map(x => {
+    f(x);
+    return x;
+  });
+}

--- a/test/debug.ts
+++ b/test/debug.ts
@@ -1,0 +1,55 @@
+import * as assert from 'assert';
+import { pipe, debug, subscribe, fromArray } from '../src/index';
+
+describe('debug', () => {
+  const log = console.log;
+
+  it('should log to console when given a string', () => {
+    const logs: [string, number][] = [];
+    console.log = (x: string, y: number) => {
+      logs.push([x, y]);
+    };
+    let called = false;
+
+    pipe(
+      fromArray([1, 2, 3, 4]),
+      debug('message'),
+      subscribe(
+        () => {},
+        () => {
+          const expected = [
+            ['message', 1],
+            ['message', 2],
+            ['message', 3],
+            ['message', 4],
+          ];
+          assert.deepStrictEqual(logs, expected);
+          called = true;
+        }
+      )
+    );
+
+    assert.strictEqual(called, true);
+    console.log = log;
+  });
+
+  it('should call given function with data', () => {
+    const logs: number[] = [];
+    const expected = [1, 2, 3, 4];
+    let called = false;
+
+    pipe(
+      fromArray(expected),
+      debug(x => logs.push(x)),
+      subscribe(
+        () => {},
+        () => {
+          assert.deepStrictEqual(logs, expected);
+          called = true;
+        }
+      )
+    );
+
+    assert.strictEqual(called, true);
+  });
+});


### PR DESCRIPTION
This operator can be inserted in a callbag chain (e.g. in a call to
`pipe`) to log all the events that flow through

While this is not needed to run cyclejs, I often miss it during the development